### PR TITLE
Add SetClient function and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ func Children() []Root {} // Find all direct children of this DOM element
 func Attrs() map[string]string {} // Map returned with all the attributes of the Element as lookup to their respective values
 func Text() string {} // Full text inside a non-nested tag returned, first half returned in a nested one
 func FullText() string {} // Full text inside a nested/non-nested tag returned
+func SetClient(*http.Client) {} // Sets the default HTTP client to a custom client, useful for routing all HTTP requests through a proxy 
 func SetDebug(bool) {} // Sets the debug mode to true or false; false by default
 func HTML() {} // HTML returns the HTML code for the specific element
 ```

--- a/soup.go
+++ b/soup.go
@@ -85,6 +85,11 @@ var (
 	Cookies = make(map[string]string)
 )
 
+// SetClient sets the defaultClient
+func SetClient(client *http.Client) {
+	defaultClient = client
+}
+
 // SetDebug sets the debug status
 // Setting this to true causes the panics to be thrown and logged onto the console.
 // Setting this to false causes the errors to be saved in the Error field in the returned struct.


### PR DESCRIPTION
Enable setting the default HTTP client to a custom client, useful for routing all HTTP requests through a proxy 